### PR TITLE
feat: Redesign polls application UI

### DIFF
--- a/apps/polls/static/polls/css/detail.css
+++ b/apps/polls/static/polls/css/detail.css
@@ -1,0 +1,140 @@
+/* --- Common Styles --- */
+body {
+    font-family: 'Noto Sans JP', sans-serif;
+    background-color: #f4f6f8;
+    color: #212529;
+    margin: 0;
+    padding: 20px;
+    line-height: 1.6;
+}
+
+.container {
+    max-width: 800px;
+    margin: 0 auto;
+    background-color: #ffffff;
+    padding: 20px 40px;
+    border-radius: 8px;
+    box-shadow: 0 4px 8px rgba(0, 0, 0, 0.05);
+}
+
+header {
+    border-bottom: 1px solid #dee2e6;
+    margin-bottom: 30px;
+    padding-bottom: 20px;
+}
+
+header h1 {
+    font-size: 2.5rem;
+    margin: 0;
+    text-align: center;
+}
+
+.header-title {
+    text-decoration: none;
+    color: #212529;
+}
+
+main {
+    padding: 0;
+}
+
+/* --- Detail Page Specific Styles --- */
+.poll-form fieldset {
+    border: none;
+    padding: 0;
+    margin: 0;
+}
+
+.poll-question {
+    font-size: 1.8rem;
+    font-weight: 700;
+    margin-bottom: 25px;
+    text-align: center;
+}
+
+.error-message {
+    background-color: #f8d7da;
+    color: #721c24;
+    border: 1px solid #f5c6cb;
+    border-radius: 5px;
+    padding: 10px 15px;
+    margin-bottom: 20px;
+    text-align: center;
+}
+
+.choices {
+    margin-bottom: 25px;
+}
+
+.choice {
+    display: flex;
+    align-items: center;
+    margin-bottom: 15px;
+    padding: 10px;
+    border-radius: 5px;
+    transition: background-color 0.2s ease-in-out;
+}
+
+.choice:hover {
+    background-color: #f8f9fa;
+}
+
+.choice input[type="radio"] {
+    margin-right: 15px;
+    width: 18px;
+    height: 18px;
+    accent-color: #007bff;
+}
+
+.choice label {
+    font-size: 1.1rem;
+    cursor: pointer;
+    flex-grow: 1;
+}
+
+.vote-button {
+    display: block;
+    width: 100%;
+    padding: 12px 20px;
+    font-size: 1.1rem;
+    font-weight: 700;
+    color: #ffffff;
+    background-color: #007bff;
+    border: none;
+    border-radius: 5px;
+    cursor: pointer;
+    transition: background-color 0.2s ease-in-out;
+}
+
+.vote-button:hover {
+    background-color: #0056b3;
+}
+
+.back-link-container {
+    margin-top: 30px;
+    text-align: center;
+}
+
+.back-link {
+    text-decoration: none;
+    color: #007bff;
+}
+
+.back-link:hover {
+    text-decoration: underline;
+}
+
+/* --- Responsive Design --- */
+@media (max-width: 600px) {
+    .container {
+        padding: 15px 20px;
+    }
+
+    header h1 {
+        font-size: 2rem;
+    }
+
+    .poll-question {
+        font-size: 1.5rem;
+    }
+}

--- a/apps/polls/static/polls/css/index.css
+++ b/apps/polls/static/polls/css/index.css
@@ -1,0 +1,89 @@
+/* --- Common Styles --- */
+body {
+    font-family: 'Noto Sans JP', sans-serif;
+    background-color: #f4f6f8;
+    color: #212529;
+    margin: 0;
+    padding: 20px;
+    line-height: 1.6;
+}
+
+.container {
+    max-width: 800px;
+    margin: 0 auto;
+    background-color: #ffffff;
+    padding: 20px 40px;
+    border-radius: 8px;
+    box-shadow: 0 4px 8px rgba(0, 0, 0, 0.05);
+}
+
+header {
+    border-bottom: 1px solid #dee2e6;
+    margin-bottom: 30px;
+    padding-bottom: 20px;
+}
+
+header h1 {
+    font-size: 2.5rem;
+    margin: 0;
+    text-align: center;
+}
+
+.header-title {
+    text-decoration: none;
+    color: #212529;
+}
+
+main {
+    padding: 0;
+}
+
+/* --- Index Page Specific Styles --- */
+.question-list {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+}
+
+.question-list li {
+    background-color: #f8f9fa;
+    border: 1px solid #dee2e6;
+    border-radius: 5px;
+    margin-bottom: 10px;
+    transition: background-color 0.2s ease-in-out, box-shadow 0.2s ease-in-out;
+}
+
+.question-list li:hover {
+    background-color: #e9ecef;
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.07);
+}
+
+.question-list li a {
+    display: block;
+    padding: 15px 20px;
+    text-decoration: none;
+    color: #007bff;
+    font-size: 1.1rem;
+    font-weight: 500;
+}
+
+.question-list li a:hover {
+    text-decoration: underline;
+}
+
+.no-polls {
+    color: #6c757d;
+    text-align: center;
+    padding: 40px 0;
+}
+
+/* --- Responsive Design --- */
+@media (max-width: 600px) {
+    .container {
+        padding: 15px 20px;
+    }
+
+    header h1 {
+        font-size: 2rem;
+    }
+}

--- a/apps/polls/static/polls/css/results.css
+++ b/apps/polls/static/polls/css/results.css
@@ -1,0 +1,114 @@
+/* --- Common Styles --- */
+body {
+    font-family: 'Noto Sans JP', sans-serif;
+    background-color: #f4f6f8;
+    color: #212529;
+    margin: 0;
+    padding: 20px;
+    line-height: 1.6;
+}
+
+.container {
+    max-width: 800px;
+    margin: 0 auto;
+    background-color: #ffffff;
+    padding: 20px 40px;
+    border-radius: 8px;
+    box-shadow: 0 4px 8px rgba(0, 0, 0, 0.05);
+}
+
+header {
+    border-bottom: 1px solid #dee2e6;
+    margin-bottom: 30px;
+    padding-bottom: 20px;
+}
+
+header h1 {
+    font-size: 2.5rem;
+    margin: 0;
+    text-align: center;
+}
+
+.header-title {
+    text-decoration: none;
+    color: #212529;
+}
+
+main {
+    padding: 0;
+}
+
+/* --- Results Page Specific Styles --- */
+.poll-question {
+    font-size: 1.8rem;
+    font-weight: 700;
+    margin-bottom: 25px;
+    text-align: center;
+}
+
+.results-list {
+    list-style: none;
+    padding: 0;
+    margin: 0 0 30px 0;
+}
+
+.result-item {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 15px;
+    margin-bottom: 10px;
+    background-color: #f8f9fa;
+    border: 1px solid #dee2e6;
+    border-radius: 5px;
+}
+
+.choice-text {
+    font-size: 1.1rem;
+    font-weight: 500;
+}
+
+.vote-count {
+    font-size: 1.1rem;
+    font-weight: 700;
+    color: #007bff;
+}
+
+.action-links {
+    text-align: center;
+    display: flex;
+    justify-content: center;
+    gap: 20px;
+}
+
+.action-link {
+    text-decoration: none;
+    color: #007bff;
+    font-size: 1rem;
+}
+
+.action-link:hover {
+    text-decoration: underline;
+}
+
+
+/* --- Responsive Design --- */
+@media (max-width: 600px) {
+    .container {
+        padding: 15px 20px;
+    }
+
+    header h1 {
+        font-size: 2rem;
+    }
+
+    .poll-question {
+        font-size: 1.5rem;
+    }
+
+    .result-item {
+        flex-direction: column;
+        align-items: flex-start;
+        gap: 5px;
+    }
+}

--- a/apps/polls/static/polls/style.css
+++ b/apps/polls/static/polls/style.css
@@ -1,3 +1,0 @@
-li a {
-    color: green;
-}

--- a/apps/polls/templates/polls/detail.html
+++ b/apps/polls/templates/polls/detail.html
@@ -1,28 +1,44 @@
 <!DOCTYPE html>
-<html>
+<html lang="ja">
 
 <head>
-    <title>Poll Detail</title>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{{ question.question_text }}</title>
     {% load static %}
-    <link rel="stylesheet" href="{% static 'polls/style.css' %}">
+    <link rel="stylesheet" href="{% static 'polls/css/detail.css' %}">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@400;700&display=swap" rel="stylesheet">
 </head>
 
 <body>
-    <form action="{% url 'polls:vote' question.id %}" method="post">
-        {% csrf_token %}
-        <fieldset>
-            <legend>
-                <h1>{{ question.question_text }}</h1>
-            </legend>
-            {% if error_message %}<p><strong>{{ error_message }}</strong></p>{% endif %}
-            {% for choice in question.choices.all %}
-            <input type="radio" name="choice" id="choice{{ forloop.counter }}" value="{{ choice.id }}">
-            <label for="choice{{ forloop.counter }}">{{ choice.choice_text }}</label><br>
-            {% endfor %}
-        </fieldset>
-        <input type="submit" value="Vote">
-    </form><br>
-    <a href="{% url 'polls:index' %}">Back to the List</a>
+    <div class="container">
+        <header>
+            <h1><a href="{% url 'polls:index' %}" class="header-title">Polls Application</a></h1>
+        </header>
+        <main>
+            <form action="{% url 'polls:vote' question.id %}" method="post" class="poll-form">
+                {% csrf_token %}
+                <fieldset>
+                    <legend class="poll-question">{{ question.question_text }}</legend>
+                    {% if error_message %}<p class="error-message"><strong>{{ error_message }}</strong></p>{% endif %}
+                    <div class="choices">
+                        {% for choice in question.choices.all %}
+                        <div class="choice">
+                            <input type="radio" name="choice" id="choice{{ forloop.counter }}" value="{{ choice.id }}">
+                            <label for="choice{{ forloop.counter }}">{{ choice.choice_text }}</label>
+                        </div>
+                        {% endfor %}
+                    </div>
+                    <input type="submit" value="Vote" class="vote-button">
+                </fieldset>
+            </form>
+            <div class="back-link-container">
+                <a href="{% url 'polls:index' %}" class="back-link">&larr; Back to the List</a>
+            </div>
+        </main>
+    </div>
 </body>
 
 </html>

--- a/apps/polls/templates/polls/index.html
+++ b/apps/polls/templates/polls/index.html
@@ -1,22 +1,34 @@
 <!DOCTYPE html>
-<html>
+<html lang="ja">
 
 <head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Polls</title>
     {% load static %}
-    <link rel="stylesheet" href="{% static 'polls/style.css' %}">
+    <link rel="stylesheet" href="{% static 'polls/css/index.css' %}">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@400;700&display=swap" rel="stylesheet">
 </head>
 
 <body>
-    <img src="{% static 'polls/images/ballot_box.png' %}" alt="Ballot Box" style="margin-top: 20px;">
-    {% if latest_question_list %}
-    <ul>
-        {% for question in latest_question_list %}
-        <li><a href="{% url 'polls:detail' question.id %}">{{ question.question_text }}</a></li>
-        {% endfor %}
-    </ul>
-    {% else %}
-    <p>No polls are available.</p>
-    {% endif %}
+    <div class="container">
+        <header>
+            <h1><a href="{% url 'polls:index' %}" class="header-title">Polls Application</a></h1>
+        </header>
+        <main>
+            {% if latest_question_list %}
+            <ul class="question-list">
+                {% for question in latest_question_list %}
+                <li><a href="{% url 'polls:detail' question.id %}">{{ question.question_text }}</a></li>
+                {% endfor %}
+            </ul>
+            {% else %}
+            <p class="no-polls">No polls are available.</p>
+            {% endif %}
+        </main>
+    </div>
 </body>
 
 </html>

--- a/apps/polls/templates/polls/results.html
+++ b/apps/polls/templates/polls/results.html
@@ -1,23 +1,40 @@
 <!DOCTYPE html>
-<html>
+<html lang="ja">
 
 <head>
-    <title>Poll Results</title>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Results: {{ question.question_text }}</title>
     {% load static %}
-    <link rel="stylesheet" href="{% static 'polls/style.css' %}">
+    <link rel="stylesheet" href="{% static 'polls/css/results.css' %}">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@400;700&display=swap" rel="stylesheet">
 </head>
 
 <body>
-    <h1>{{ question.question_text }}</h1>
+    <div class="container">
+        <header>
+            <h1><a href="{% url 'polls:index' %}" class="header-title">Polls Application</a></h1>
+        </header>
+        <main>
+            <h2 class="poll-question">{{ question.question_text }}</h2>
 
-    <ul>
-        {% for choice in question.choices.all %}
-        <li>{{ choice.choice_text }} -- {{ choice.votes }} vote{{ choice.votes|pluralize }}</li>
-        {% endfor %}
-    </ul>
+            <ul class="results-list">
+                {% for choice in question.choices.all %}
+                <li class="result-item">
+                    <span class="choice-text">{{ choice.choice_text }}</span>
+                    <span class="vote-count">{{ choice.votes }} vote{{ choice.votes|pluralize }}</span>
+                </li>
+                {% endfor %}
+            </ul>
 
-    <a href="{% url 'polls:detail' question.id %}">Vote again?</a><br>
-    <a href="{% url 'polls:index' %}">Back to the List</a>
+            <div class="action-links">
+                <a href="{% url 'polls:detail' question.id %}" class="action-link">Vote again?</a>
+                <a href="{% url 'polls:index' %}" class="action-link">Back to the List</a>
+            </div>
+        </main>
+    </div>
 </body>
 
 </html>


### PR DESCRIPTION
This commit completely overhauls the frontend of the polls application to implement a modern, clean, and minimalist user interface.

- Replaced the single basic stylesheet with three new, page-specific CSS files (`index.css`, `detail.css`, `results.css`) in a new `css` directory.
- Updated all three HTML templates (`index.html`, `detail.html`, `results.html`) to use the new stylesheets and added appropriate structure and classes for styling.
- Implemented all design requirements, including:
  - A centered, responsive layout with a maximum width.
  - A modern color palette and typography using the 'Noto Sans JP' Google Font.
  - Card-based styling for list items with hover effects.
  - Custom styling for buttons, links, and form elements.
- Removed the old, unused `style.css` file.