### PR TITLE
Fix: Improve Dockerfile build process and runtime

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ ENV PYTHONUNBUFFERED=1
 WORKDIR /app
 
 # --- 依存関係のインストール ---
-RUN pip install pipx && pipx ensurepath && pipx install poetry
+RUN pip install pipx && pipx install poetry
 
 # Add pipx's bin directory to the PATH
 ENV PATH="/root/.local/bin:${PATH}"
@@ -20,13 +20,16 @@ ENV PATH="/root/.local/bin:${PATH}"
 COPY poetry.lock pyproject.toml ./
 RUN poetry config virtualenvs.create true \
     && poetry config virtualenvs.in-project true \
-    && poetry install --no-root --without dev
+    && poetry install --no-root --only main
 
 # --- アプリケーションコードのコピー ---
 COPY . .
 
 # --- ポートの開放 ---
 EXPOSE 8000
+
+# Poetryの仮想環境をPATHに通す
+ENV PATH="/app/.venv/bin:${PATH}"
 
 # --- コンテナ起動コマンド ---
 CMD ["gunicorn", "polls-site.wsgi:application", "--bind", "0.0.0.0:8000"]


### PR DESCRIPTION
This commit addresses several feedback points to improve the Dockerfile:

- Removes redundant `pipx ensurepath` to speed up the build.
- Uses `--only main` for `poetry install` to make dependency installation more explicit and robust.
- Adds the Poetry virtual environment to the `PATH` to ensure gunicorn is found at runtime.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* バグ修正
  * 仮想環境の PATH を優先し、実行ファイル（例: gunicorn）の解決性を向上。
* 雑務
  * 依存関係のインストールを main グループに限定し、不要な開発依存を除外。
  * PATH 設定を整理し、不要な PATH 追加処理を削除。
  * Docker イメージの軽量化とビルドの一貫性・信頼性を改善。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->